### PR TITLE
(SIMP-5433) SNMPD Updates

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -77,33 +77,28 @@ pup4_10-unit:
   <<: *setup_bundler_env
   <<: *spec_tests
 
-
-# Puppet 5.3 for PE 2017.3 support (EOL: 2018-07)
-# See: https://puppet.com/misc/puppet-enterprise-lifecycle
 # --------------------------------------
-pup5_3-validation:
+pup5_5-validation:
   stage: validation
   tags:
     - docker
   image: ruby:2.4
   variables:
-    PUPPET_VERSION: '~> 5.3.0'
+    PUPPET_VERSION: '~> 5.5.0'
   <<: *cache_bundler
   <<: *setup_bundler_env
   <<: *validation_checks
 
-pup5_3-unit:
+pup5_5-unit:
   stage: unit
   tags:
     - docker
   image: ruby:2.4
   variables:
-    PUPPET_VERSION: '~> 5.3.0'
+    PUPPET_VERSION: '~> 5.5.0'
   <<: *cache_bundler
   <<: *setup_bundler_env
   <<: *spec_tests
-  allow_failure: true
-
 
 # Keep an eye on the latest puppet 5
 # ----------------------------------
@@ -117,7 +112,6 @@ pup5_latest-validation:
   <<: *cache_bundler
   <<: *setup_bundler_env
   <<: *validation_checks
-  allow_failure: true
 
 pup5_latest-unit:
   stage: unit
@@ -129,9 +123,6 @@ pup5_latest-unit:
   <<: *cache_bundler
   <<: *setup_bundler_env
   <<: *spec_tests
-  allow_failure: true
-
-
 
 # Acceptance tests
 # ==============================================================================

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,6 @@ before_install:
   - rm -f Gemfile.lock
 
 jobs:
-  allow_failures:
-    - env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5.0"
-
   include:
     - stage: check
       rvm: 2.4.4

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Oct 26 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 0.1.0
+- Changed name back to razorsedge because we have not updated
+  the puppet-snmp module yet
+
 * Wed Oct 24 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 0.1.0
 - Update to puppet 5
 - Moved common parameters to init to help ease of use.

--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,7 @@
       "version_requirement": ">= 6.0.0 < 7.0.0"
     },
     {
-      "name": "puppet/snmp",
+      "name": "razorsedge/snmp",
       "version_requirement": ">= 3.9.0 < 5.0.0"
     },
     {


### PR DESCRIPTION
- Changes snmp module back to razorsedge because we have
  not updated puppet-snmp yet because they have not released
  the new version

SIMP-5433 #comment just a minor fix