### PR TITLE
(SIMP-6110) Use (namespaced) simplib::passgen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ addons:
 
 before_install:
   - rm -f Gemfile.lock
+  - gem install -v '~> 1.17' bundler
 
 global:
   - STRICT_VARIABLES=yes

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Tue Feb 12 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 0.1.2-0
+- Use simplib::passgen() in lieu of passgen(), a deprecated simplib
+  Puppet 3 function.
+
 * Wed Nov 21 2018 Adam Yohrling <adam.yohrling@onyxpoint.com> - 0.1.1-0
 - Add Oracle Linux Support
 

--- a/manifests/rsync.pp
+++ b/manifests/rsync.pp
@@ -20,7 +20,7 @@ class simp_snmpd::rsync{
 
     rsync { 'snmp_dlmod':
       user         => "snmp_${::environment}_${_downcase_os_name}",
-      password     => passgen("snmp_${::environment}_${_downcase_os_name}"),
+      password     => simplib::passgen("snmp_${::environment}_${_downcase_os_name}"),
       source       => "${simp_snmpd::rsync_source}/dlmod",
       target       => $simp_snmpd::rsync_dlmod_dir,
       server       => $simp_snmpd::rsync_server,
@@ -55,7 +55,7 @@ class simp_snmpd::rsync{
 
     rsync { 'snmpd_mibs':
       user     => "snmp_${::environment}_${_downcase_os_name}",
-      password => passgen("snmp_${::environment}_${_downcase_os_name}"),
+      password => simplib::passgen("snmp_${::environment}_${_downcase_os_name}"),
       server   => $simp_snmpd::rsync_server,
       timeout  => $simp_snmpd::rsync_timeout,
       source   => "${simp_snmpd::rsync_source}/mibs",

--- a/manifests/v3/users.pp
+++ b/manifests/v3/users.pp
@@ -11,12 +11,12 @@ class simp_snmpd::v3::users (
   $simp_snmpd::v3_users_hash.each |String $username, Optional[Hash] $settings| {
     if $settings {
       $_authpass = $settings['authpass'] ? {
-        /(undef|UNDEF)/  => passgen("snmp_auth_${username}"),
-        undef            => passgen("snmp_auth_${username}"),
+        /(undef|UNDEF)/  => simplib::passgen("snmp_auth_${username}"),
+        undef            => simplib::passgen("snmp_auth_${username}"),
         default          => $settings['authpass'] }
       $_privpass = $settings['privpass'] ? {
-        /(undef|UNDEF)/ => passgen("snmp_priv_${username}"),
-        undef           => passgen("snmp_priv_${username}"),
+        /(undef|UNDEF)/ => simplib::passgen("snmp_priv_${username}"),
+        undef           => simplib::passgen("snmp_priv_${username}"),
         default         => $settings['privpass'] }
       $_authtype = $settings['authtype'] ? {
         undef   => $simp_snmpd::defauthtype,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_snmpd",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": "SIMP Team",
   "summary": "Configures snmpd agent using v3 USM on the client",
   "license": "Apache-2.0",
@@ -15,7 +15,7 @@
   "dependencies": [
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 3.1.0 < 4.0.0"
+      "version_requirement": ">= 3.5.0 < 4.0.0"
     },
     {
       "name": "simp/iptables",


### PR DESCRIPTION
Use simplib::passgen() in lieu of passgen(), a deprecated simplib
Puppet 3 function.

SIMP-6110 #comment pupmod-simp-simp_snmpd