### PR TITLE
(SIMP-6213) Use latest concat in tests

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,11 +1,7 @@
 ---
 fixtures:
   repositories:
-    concat:
-      # master is beyond 4.1.1, but has breaking changes to
-      # how fragments are ordered (MODULES-6625)
-      repo: https://github.com/simp/puppetlabs-concat
-      ref: 4.1.1
+    concat: https://github.com/simp/puppetlabs-concat
     iptables:  https://github.com/simp/pupmod-simp-iptables
     logrotate: https://github.com/simp/pupmod-simp-logrotate
     pki:       https://github.com/simp/pupmod-simp-pki

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 * Tue Feb 12 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 0.1.2-0
 - Use simplib::passgen() in lieu of passgen(), a deprecated simplib
   Puppet 3 function.
+- Expanded the upper limit of the stdlib Puppet module version
+- Updated a URL in the README.md
 
 * Wed Nov 21 2018 Adam Yohrling <adam.yohrling@onyxpoint.com> - 0.1.1-0
 - Add Oracle Linux Support

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ supported operating systems, Puppet versions, and module dependencies.
 
 ## Development
 
-Please read our [Contribution Guide](http://simp-doc.readthedocs.io/en/stable/contributors_guide/index.html).
+Please read our [Contribution Guide](https://simp.readthedocs.io/en/stable/contributors_guide/index.html).
 
 ### Acceptance tests
 

--- a/metadata.json
+++ b/metadata.json
@@ -39,7 +39,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.0 < 5.0.0"
+      "version_requirement": ">= 4.13.0 < 6.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
- Test with latest concat Puppet module instead of 4.1.1
- Expanded the upper limit of the stdlib Puppet module version
- Updated a URL in the README.md

SIMP-6213 #comment pupmod-simp-simp_snmpd