### PR TITLE
(SIMP-5852) Update to puppet-snmp 4.1.0

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -10,7 +10,7 @@ fixtures:
     simplib:   https://github.com/simp/pupmod-simp-simplib
     snmp:
       repo:  https://github.com/simp/puppet-snmp
-      ref:   3.9.0
+      ref:   v4.1.0
     stdlib:  https://github.com/simp/puppetlabs-stdlib
     systemd:
       repo: https://github.com/simp/puppet-systemd

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,9 @@
   Puppet 3 function.
 - Expanded the upper limit of the stdlib Puppet module version
 - Updated a URL in the README.md
+- Update miniminum version of snmp module to 4.1.0.  This project
+  is now maintained by Vox Pupuli and has changed from razorsedge-snmp
+  to puppet-snmp.
 
 * Wed Nov 21 2018 Adam Yohrling <adam.yohrling@onyxpoint.com> - 0.1.1-0
 - Add Oracle Linux Support

--- a/metadata.json
+++ b/metadata.json
@@ -26,8 +26,8 @@
       "version_requirement": ">= 6.0.0 < 7.0.0"
     },
     {
-      "name": "razorsedge/snmp",
-      "version_requirement": ">= 3.9.0 < 5.0.0"
+      "name": "puppet/snmp",
+      "version_requirement": ">= 4.1.0 < 5.0.0"
     },
     {
       "name": "simp/rsync",


### PR DESCRIPTION
Update miniminum version of snmp module to 4.1.0.  This project
is now maintained by Vox Pupuli and has changed from razorsedge-snmp
to puppet-snmp.

SIMP-5852 #comment pupmod-simp-simp_snmpd