### PR TITLE
(SIMP-10174) simp_snmpd Add Puppet 7 acceptance test

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -8,9 +8,7 @@ fixtures:
     pki: https://github.com/simp/pupmod-simp-pki.git
     rsync: https://github.com/simp/pupmod-simp-rsync.git
     rsyslog: https://github.com/simp/pupmod-simp-rsyslog.git
-    selinux_core:
-      repo: https://github.com/simp/pupmod-puppetlabs-selinux_core.git
-      puppet_version: ">= 6.0.0"
+    selinux_core: https://github.com/simp/pupmod-puppetlabs-selinux_core.git
     simp_firewalld: https://github.com/simp/pupmod-simp-simp_firewalld.git
     simplib: https://github.com/simp/pupmod-simp-simplib.git
     snmp: https://github.com/simp/puppet-snmp.git

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -368,3 +368,9 @@ pup6.pe-oel-fips:
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,oel]'
+
+pup7.x:
+  <<: *pup_7_x
+  <<: *acceptance_base
+  script:
+    - 'bundle exec rake beaker:suites[default,default]'

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -19,7 +19,7 @@ HOSTS:
     roles:
       - el8
     platform:   el-8-x86_64
-    box:        centos/8
+    box:        generic/centos8
     hypervisor: <%= hypervisor %>
 CONFIG:
   log_level: verbose

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -20,6 +20,10 @@ RSpec.configure do |c|
   # ensure that environment OS is ready on each host
   fix_errata_on hosts
 
+  # Detect cases in which no examples are executed (e.g., nodeset does not
+  # have hosts with required roles)
+  c.fail_if_no_examples = true
+
   # Readable test descriptions
   c.formatter = :documentation
 


### PR DESCRIPTION
* Add a Puppet 7 acceptance test
* Test with CentOS 8.4 via generic/centos8 box
* Remove check for Puppet >=6 in .fixtures.yml
* Fail acceptance tests if no examples are executed.

[SIMP-9666] #comment pupmod-simp-simp_snmpd acceptance tests configured
SIMP-10174 #close

[SIMP-9666]: https://simp-project.atlassian.net/browse/SIMP-9666