### PR TITLE
[puppetsync] Support simp-iptables 7.x

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Sep 13 2024 Steven Pritchard <steve@sicura.us> - 1.7.0
+- [puppetsync] Update module dependencies to support simp-iptables 7.x
+
 * Wed Feb 07 2024 Mike Riddle <mike@sicura.us> - 1.6.0
 - [puppetsync] Update metadata upper bounds for puppet-nsswitch, puppet-gitlab, puppet-snmp, simp-pam, and simp-useradd
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_snmpd",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "author": "SIMP Team",
   "summary": "Configures snmpd agent using v3 USM on the client",
   "license": "Apache-2.0",
@@ -30,7 +30,7 @@
     "optional_dependencies": [
       {
         "name": "simp/iptables",
-        "version_requirement": ">= 6.5.3 < 7.0.0"
+        "version_requirement": ">= 6.5.3 < 8.0.0"
       },
       {
         "name": "simp/logrotate",

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -96,7 +96,6 @@ RSpec.configure do |c|
   c.mock_with :rspec
 
   c.module_path = File.join(fixture_path, 'modules')
-  c.manifest_dir = File.join(fixture_path, 'manifests') if c.respond_to?(:manifest_dir)
 
   c.hiera_config = File.join(fixture_path, 'hieradata', 'hiera.yaml')
 


### PR DESCRIPTION
Update module dependencies to support simp-iptables 7.x.